### PR TITLE
Added support for Apple MAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ The HIDAPI library must be installed for the streamdeck Python module to work co
   - Download the latest `hidapi-win.zip` file from https://github.com/libusb/hidapi/releases
   - Copy the `hidapi.dll` file inside the ZIP file into `C:\Windows\System32` as administrator
 
+### Mac-specific
 
+You need to install the hidapi in your system. The easiest way is using homebrew. 
+
+```bash
+brew install hidapi
+```
 
 ## Settings
 

--- a/parameters.py
+++ b/parameters.py
@@ -131,6 +131,7 @@ class UserParameters():
     # Add the non user-editable parameters
     self.streamdeck_key_text_font_filename_linux = "OpenSans-Regular.ttf"
     self.streamdeck_key_text_font_filename_windows = "arial.ttf"
+    self.streamdeck_key_text_font_filename_mac = "Arial.ttf"
     self.streamdeck_key_text_font_size = 14
     self.prev_streamdeck_key_icon = "prev.png"
     self.next_streamdeck_key_icon = "next.png"

--- a/streamdeck_addon.py
+++ b/streamdeck_addon.py
@@ -440,6 +440,7 @@ def start(FreeCAD):
 
   # Determine the platform
   is_win = sys.platform[0:3] == "win"
+  is_mac = sys.platform == "darwin"
 
   # Determine the installation directory
   install_dir = os.path.dirname(__file__)
@@ -462,6 +463,8 @@ def start(FreeCAD):
   # depending on the platform
   font_filename = params.streamdeck_key_text_font_filename_windows \
 				if is_win else \
+      params.streamdeck_key_text_font_filename_mac \
+        if is_mac else \
 			params.streamdeck_key_text_font_filename_linux
 
   # Initialize the streamdeck object


### PR DESCRIPTION
Added support for Apple MAC.

In Apple the font to load is named "Arial.ttf".:
- Added a new config in parameters.py
- Added the system identification and font diferenciation in streamdeck_addon.py file.
- Added how to install hidapi using homebrew in README.md